### PR TITLE
Fixed CB-9697 Cordova emulate for Android versions 4.1.1 does not work

### DIFF
--- a/bin/templates/cordova/lib/emulator.js
+++ b/bin/templates/cordova/lib/emulator.js
@@ -336,7 +336,7 @@ module.exports.install = function(givenTarget, buildResults) {
 
         var retriedInstall = retry.retryPromise(
             NUM_INSTALL_RETRIES,
-            exec, 'adb -s ' + target.target + ' install -r -d "' + apk_path + '"', os.tmpdir(), execOptions
+            exec, 'adb -s ' + target.target + ' install -r "' + apk_path + '"', os.tmpdir(), execOptions
         );
 
         return retriedInstall.then(function (output) {


### PR DESCRIPTION
After running 'cordova emulate android' the apk is not installed & shown on the emulator despite the log shows the app is successfully launched.

This issue is related to https://issues.apache.org/jira/browse/CB-9080 and https://issues.apache.org/jira/browse/CB-8912. These two previous issues fix the problem in 'device.js' and error in 'emulator.js' is still not corrected.

The `emulator.js` file try to run this command:

exec, 'adb -s ' + target.target + ' install -r -d "' + apk_path + '"', os.tmpdir(), execOptions

The '-d' option is not supported by Android 4.1.1

Remove the '-d' option will fix this issue.
